### PR TITLE
Simplify Ryujinx instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # _vita2hos_
+
 A PlayStation Vita to Horizon OS (Nintendo Switch OS) translation layer (**_not_** an emulator)
 
 ## How does it work?
@@ -13,6 +14,7 @@ When loading a PlayStation Vita executable, _vita2hos_ redirects the [module](ht
 
 1. Copy `vita2hos.nsp` to your microSD card (i.e. to: `atmosphere/vita2hos.nsp`)
 2. Create [`atmosphere/config/override_config.ini`](https://github.com/Atmosphere-NX/Atmosphere/blob/master/config_templates/override_config.ini) and add the following lines to it:
+
     ```ini
     [hbl_config]
     override_any_app=true
@@ -40,24 +42,19 @@ When loading a PlayStation Vita executable, _vita2hos_ redirects the [module](ht
 4. Enjoy!
 
 #### Notes:
+
 Make sure to use a very recent build of [yuzu](https://yuzu-emu.org/downloads/), such as _Mainline_ or _Early Access Builds_.
 
 ### Running it on Ryujinx
 
 1. Copy a PlayStation Vita executable (`.velf` or `.self`/`eboot.bin`) to `sd:/vita2hos/test.elf` (_File_ → _Open Ryujinx Folder_ → `sdcard/`)
-2. Extract `main` and `main.npdm` from `vita2hos.nsp` to a directory
-
-    Using [hactool](https://github.com/SciresM/hactool):
-    ```
-    hactool -t pfs0 --pfs0dir=vita2hos vita2hos.nsp
-    ```
-    This will extract `main` and `main.npdm` to a directory named `vita2hos`.
-3. Disable PPTC (_Options_ → _Settings_ → _System_ → Unselect _Enable PPTC (Profiled Persistent Translation Cache)_)
-4. Load the directory containing `main` and `main.npdm` (_File_ → _Load Unpacked Game_)
-5. Enjoy!
+2. Disable PPTC (_Options_ → _Settings_ → _System_ → Unselect _Enable PPTC (Profiled Persistent Translation Cache)_)
+3. Run `vita2hos.nsp`
+4. Enjoy!
 
 #### Notes:
-- _vita2hos_ depends on @gdkchan's Ryujinx [`codemem2` branch](https://github.com/gdkchan/Ryujinx/tree/codemem2)
+
+- Ryujinx >= 1.1.133 is required
 - Some ARM Thumb instructions are not yet implemented on Ryujinx
 
 ## Project status, compatibility and supported features
@@ -69,6 +66,7 @@ There is very initial 3D graphics support (it can run vitasdk's GXM triangle and
 ## Special Thanks
 
 A few noteworthy teams/projects who've helped along the way are:
+
 * **[Vita3K](https://vita3k.org/)**
 
     _vita2hos_ uses Vita3K's shader recompiler, and some parts of _vita2hos_'s code are based on Vita3K's implementation. Please, consider [**donating**](https://vita3k.org/#donate) and [**contributing**](https://vita3k.org/#contribute) to Vita3K!


### PR DESCRIPTION
Now that Ryujinx supports [booting homebrew nsps](https://github.com/Ryujinx/Ryujinx/pull/3364) without workarounds, we can simplify the instructions a little bit.

And [codemem2](https://github.com/Ryujinx/Ryujinx/pull/2958) was merged a while ago, so the note for that requirement can be removed too.
