### PR TITLE
Use macros for module exports

### DIFF
--- a/include/module.h
+++ b/include/module.h
@@ -3,6 +3,11 @@
 
 #include <stdint.h>
 
+#define GET_EXPORT_NID(name) __nid_ ## name
+#define EXPORT(type, name, nid, ...) static const uint32_t GET_EXPORT_NID(name) = nid; type name(__VA_ARGS__)
+#define EXPORT_STUB EXPORT
+#define GET_EXPORT_ENTRY(name) {GET_EXPORT_NID(name), name}
+
 typedef struct {
 	uint32_t nid;
 	void *addr;

--- a/source/modules/SceTouch.c
+++ b/source/modules/SceTouch.c
@@ -8,7 +8,7 @@
 
 #define MAX_TOUCH_STATES 8
 
-int sceTouchPeek(SceUInt32 port, SceTouchData *pData, SceUInt32 nBufs)
+EXPORT(int, sceTouchPeek, 0xFF082DF0, SceUInt32 port, SceTouchData *pData, SceUInt32 nBufs)
 {
 	HidTouchScreenState states[MAX_TOUCH_STATES];
 	int total;
@@ -38,7 +38,7 @@ int sceTouchPeek(SceUInt32 port, SceTouchData *pData, SceUInt32 nBufs)
 	return total;
 }
 
-int sceTouchGetPanelInfo(SceUInt32 port, SceTouchPanelInfo *pPanelInfo)
+EXPORT(int, sceTouchGetPanelInfo, 0x10A2CA25, SceUInt32 port, SceTouchPanelInfo *pPanelInfo)
 {
 	switch (port) {
 	case SCE_TOUCH_PORT_FRONT:
@@ -73,8 +73,8 @@ int sceTouchGetPanelInfo(SceUInt32 port, SceTouchPanelInfo *pPanelInfo)
 void SceTouch_register(void)
 {
 	static const export_entry_t exports[] = {
-		{0x10A2CA25, sceTouchGetPanelInfo},
-		{0xFF082DF0, sceTouchPeek},
+		GET_EXPORT_ENTRY(sceTouchGetPanelInfo),
+		GET_EXPORT_ENTRY(sceTouchPeek),
 	};
 
 	module_register_exports(exports, ARRAY_SIZE(exports));


### PR DESCRIPTION
Convenience macros (`EXPORT`, `GET_EXPORT_ENTRY`, `GET_EXPORT_NID`) for module exports / registry
The export NID is now defined with the function declaration and can be accessed using `GET_EXPORT_NID`!
This makes registry a bit cleaner:
```
... {
  GET_EXPORT_ENTRY(sceTouchGetPanelInfo), // or:
  {GET_EXPORT_NID(sceTouchGetPanelInfo), sceTouchGetPanelInfo}
} ...
```
(this PR only updates SceTouch so we can figure out if this is a good method or not, I'll update the other modules if it is!)
